### PR TITLE
MBF21 Support -- Args & ammopershot weapon flag

### DIFF
--- a/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
@@ -1974,16 +1974,8 @@ public final class DecoHackParser extends Lexer.Parser
 
 					// get first argument
 					Integer p;
-					if (currentIdentifierLexemeIgnoreCase(KEYWORD_THING) || currentIdentifierLexemeIgnoreCase(KEYWORD_WEAPON))
-					{
-						if ((p = parseStateIndex(context, actor)) == null)
-							return false;
-					}
-					else if ((p = matchNumeric()) == null)
-					{
-						addErrorMessage("Expected parameter.");
+					if ((p = parseActionPointerParameterValue(context, actor)) == null)
 						return false;
-					}
 
 					if(!checkActionParamValue(state.action, 0, p))
 						return false;
@@ -1992,16 +1984,8 @@ public final class DecoHackParser extends Lexer.Parser
 
 					if (matchType(DecoHackKernel.TYPE_COMMA))
 					{
-						if (currentIdentifierLexemeIgnoreCase(KEYWORD_THING) || currentIdentifierLexemeIgnoreCase(KEYWORD_WEAPON))
-						{
-							if ((p = parseStateIndex(context, actor)) == null)
-								return false;
-						}
-						else if ((p = matchNumeric()) == null)
-						{
-							addErrorMessage("Expected a second parameter after ','.");
+						if ((p = parseActionPointerParameterValue(context, actor)) == null)
 							return false;
-						}
 
 						if(!checkActionParamValue(state.action, 1, p))
 							return false;
@@ -2034,24 +2018,8 @@ public final class DecoHackParser extends Lexer.Parser
 						// get argument
 						int argIndex = state.args.size();
 						Integer p;
-						if (currentIdentifierLexemeIgnoreCase(KEYWORD_THING) || currentIdentifierLexemeIgnoreCase(KEYWORD_WEAPON))
-						{
-							if ((p = parseStateIndex(context, actor)) == null)
-								return false;
-						}
-						else if ((p = matchNumeric()) == null)
-						{
-							if(argIndex == 0)
-							{
-								addErrorMessage("Expected parameter.");
-								return false;
-							}
-							else
-							{
-								addErrorMessage("Expected an additional parameter after ','.");
-								return false;
-							}
-						}
+						if ((p = parseActionPointerParameterValue(context, actor)) == null)
+							return false;
 
 						if(!checkActionParamValue(state.action, argIndex, p))
 							return false;

--- a/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
@@ -1903,16 +1903,25 @@ public final class DecoHackParser extends Lexer.Parser
 				{
 					// get first argument
 					Integer p;
-					if ((p = parseActionPointerParameterValue(context, actor)) == null)
-						return false;
-					state.misc1 = p;
-				
-					if (matchType(DecoHackKernel.TYPE_COMMA))
+					if ((p = matchInteger()) == null)
 					{
-						if ((p = parseActionPointerParameterValue(context, actor)) == null)
-							return false;
-						state.misc2 = p;
+						addErrorMessage("Expected integer for X offset value.");
+						return false;
 					}
+					state.misc1 = p;
+
+					if (!matchType(DecoHackKernel.TYPE_COMMA))
+					{
+						addErrorMessage("Expected a ',' after X offset; both X and Y offsets must be defined.");
+						return false;
+					}
+
+					if ((p = matchInteger()) == null)
+					{
+						addErrorMessage("Expected integer for Y offset value.");
+						return false;
+					}
+					state.misc2 = p;
 
 					if (!matchType(DecoHackKernel.TYPE_RPAREN))
 					{

--- a/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
@@ -1894,7 +1894,7 @@ public final class DecoHackParser extends Lexer.Parser
 		state.args.clear();
 
 		boolean useoffsets = matchOffsetDirective();
-		if( useoffsets )
+		if (useoffsets)
 		{
 			if (matchType(DecoHackKernel.TYPE_LPAREN))
 			{
@@ -1975,7 +1975,7 @@ public final class DecoHackParser extends Lexer.Parser
 					if ((p = parseActionPointerParameterValue(context, actor)) == null)
 						return false;
 
-					if(!checkActionParamValue(state.action, 0, p))
+					if (!checkActionParamValue(state.action, 0, p))
 						return false;
 
 					state.misc1 = p;
@@ -1985,7 +1985,7 @@ public final class DecoHackParser extends Lexer.Parser
 						if ((p = parseActionPointerParameterValue(context, actor)) == null)
 							return false;
 
-						if(!checkActionParamValue(state.action, 1, p))
+						if (!checkActionParamValue(state.action, 1, p))
 							return false;
 
 						state.misc2 = p;
@@ -2019,7 +2019,7 @@ public final class DecoHackParser extends Lexer.Parser
 						if ((p = parseActionPointerParameterValue(context, actor)) == null)
 							return false;
 
-						if(!checkActionParamValue(state.action, argIndex, p))
+						if (!checkActionParamValue(state.action, argIndex, p))
 							return false;
 
 						state.args.add(p);
@@ -2863,20 +2863,20 @@ public final class DecoHackParser extends Lexer.Parser
 	// pointer parameter; if not, prints an error message.
 	private boolean checkActionParamValue(DEHActionPointer action, int index, int value)
 	{
-		if(action == null || index < 0)
+		if (action == null || index < 0)
 		{
 			addErrorMessage("Error in checkActionParamValue: invalid action or index. This is a bug with DECOHack!");
 			return false;
 		}
 
 		DEHActionPointerParam[] params = action.getParams();
-		if(index >= params.length)
+		if (index >= params.length)
 		{
 			addErrorMessage("Too many args for action %s: this action expects a maximum of %d args.", action.getMnemonic(), index);
 			return false;
 		}
 
-		if(!params[index].isValueValid(value))
+		if (!params[index].isValueValid(value))
 		{
 			addErrorMessage("Invalid value '%d' for %s arg %d: value must be between %d and %d.", value, action.getMnemonic(), index, params[index].getValueMin(), params[index].getValueMax());
 			return false;

--- a/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
@@ -1807,8 +1807,8 @@ public final class DecoHackParser extends Lexer.Parser
 				.setFrameIndex(parsedState.frameList.get(0))
 				.setDuration(parsedState.duration)
 				.setBright(parsedState.bright)
-				.setParameter0(parsedState.parameter0)
-				.setParameter1(parsedState.parameter1)
+				.setMisc1(parsedState.misc1)
+				.setMisc2(parsedState.misc2)
 			;
 
 			// Try to parse next state clause.
@@ -1891,8 +1891,8 @@ public final class DecoHackParser extends Lexer.Parser
 		}
 		
 		// Maybe parse parameters.
-		state.parameter0 = 0;
-		state.parameter1 = 0;
+		state.misc1 = 0;
+		state.misc2 = 0;
 		
 		if (state.action != null || useOffsets)
 		{
@@ -1917,7 +1917,7 @@ public final class DecoHackParser extends Lexer.Parser
 					return false;
 				}
 
-				state.parameter0 = p;
+				state.misc1 = p;
 				
 				if (matchType(DecoHackKernel.TYPE_COMMA))
 				{
@@ -1932,7 +1932,7 @@ public final class DecoHackParser extends Lexer.Parser
 						return false;
 					}
 
-					state.parameter1 = p;
+					state.misc2 = p;
 				}
 
 				if (!matchType(DecoHackKernel.TYPE_RPAREN))
@@ -2130,8 +2130,8 @@ public final class DecoHackParser extends Lexer.Parser
 				.setFrameIndex(state.frameList.pollFirst())
 				.setDuration(state.duration)
 				.setBright(state.bright)
-				.setParameter0(state.parameter0)
-				.setParameter1(state.parameter1)
+				.setMisc1(state.misc1)
+				.setMisc2(state.misc2)
 			;
 	
 			if (isBoom && pointerIndex != null && state.action == null)
@@ -2841,8 +2841,8 @@ public final class DecoHackParser extends Lexer.Parser
 		private Integer duration;
 		private Boolean bright;
 		private DEHActionPointer action;
-		private Integer parameter0;
-		private Integer parameter1;
+		private Integer misc1;
+		private Integer misc2;
 		
 		private ParsedState()
 		{
@@ -2857,8 +2857,8 @@ public final class DecoHackParser extends Lexer.Parser
 			this.duration = null;
 			this.bright = null;
 			this.action = null;
-			this.parameter0 = null;
-			this.parameter1 = null;
+			this.misc1 = null;
+			this.misc2 = null;
 		}
 		
 	}

--- a/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
@@ -1884,9 +1884,9 @@ public final class DecoHackParser extends Lexer.Parser
 		{
 			useOffsets = matchOffsetDirective();
 		}
-		else if (!(context instanceof PatchMBFContext) && !(context instanceof PatchDHEExtendedContext) && !(context instanceof PatchMBF21Context) && state.action.isMBF())
+		else if (!context.isActionPointerTypeSupported(state.action.getType()))
 		{
-			addErrorMessage("MBF action pointer used: " + state.action.getMnemonic() +". Patch is not MBF or better.");
+			addErrorMessage(state.action.getType().name() + " action pointer used: " + state.action.getMnemonic() +". Patch does not support this action type.");
 			return false;
 		}
 		

--- a/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
@@ -2982,7 +2982,7 @@ public final class DecoHackParser extends Lexer.Parser
 		private DEHActionPointer action;
 		private Integer misc1;
 		private Integer misc2;
-		private LinkedList<Integer> args;
+		private List<Integer> args;
 		
 		private ParsedState()
 		{

--- a/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
@@ -1899,28 +1899,26 @@ public final class DecoHackParser extends Lexer.Parser
 			if (matchType(DecoHackKernel.TYPE_LPAREN))
 			{
 				// no arguments
-				if (matchType(DecoHackKernel.TYPE_RPAREN))
-				{
-					return true;
-				}
-
-				// get first argument
-				Integer p;
-				if ((p = parseActionPointerParameterValue(context, actor)) == null)
-					return false;
-				state.misc1 = p;
-				
-				if (matchType(DecoHackKernel.TYPE_COMMA))
-				{
-					if ((p = parseActionPointerParameterValue(context, actor)) == null)
-						return false;
-					state.misc2 = p;
-				}
-
 				if (!matchType(DecoHackKernel.TYPE_RPAREN))
 				{
-					addErrorMessage("Expected a ')' after offsets.");
-					return false;
+					// get first argument
+					Integer p;
+					if ((p = parseActionPointerParameterValue(context, actor)) == null)
+						return false;
+					state.misc1 = p;
+				
+					if (matchType(DecoHackKernel.TYPE_COMMA))
+					{
+						if ((p = parseActionPointerParameterValue(context, actor)) == null)
+							return false;
+						state.misc2 = p;
+					}
+
+					if (!matchType(DecoHackKernel.TYPE_RPAREN))
+					{
+						addErrorMessage("Expected a ')' after offsets.");
+						return false;
+					}
 				}
 			}
 			else

--- a/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
@@ -24,6 +24,7 @@ import net.mtrop.doom.tools.decohack.contexts.PatchBoomContext;
 import net.mtrop.doom.tools.decohack.contexts.PatchDHEExtendedContext;
 import net.mtrop.doom.tools.decohack.contexts.PatchDoom19Context;
 import net.mtrop.doom.tools.decohack.contexts.PatchMBFContext;
+import net.mtrop.doom.tools.decohack.contexts.PatchMBF21Context;
 import net.mtrop.doom.tools.decohack.contexts.PatchUltimateDoom19Context;
 import net.mtrop.doom.tools.decohack.data.DEHActionPointer;
 import net.mtrop.doom.tools.decohack.data.DEHActor;
@@ -172,6 +173,7 @@ public final class DecoHackParser extends Lexer.Parser
 	private static final String KEYWORD_BOOM = "boom";
 	private static final String KEYWORD_MBF = "mbf";
 	private static final String KEYWORD_EXTENDED = "extended";
+	private static final String KEYWORD_MBF21 = "mbf21";
 
 	private static final Pattern MAPLUMP_EXMY = Pattern.compile("E[0-9]+M[0-9]+", Pattern.CASE_INSENSITIVE);
 	private static final Pattern MAPLUMP_MAPXX = Pattern.compile("MAP[0-9][0-9]+", Pattern.CASE_INSENSITIVE);
@@ -273,10 +275,12 @@ public final class DecoHackParser extends Lexer.Parser
 			return new PatchMBFContext();
 		else if (matchIdentifierLexemeIgnoreCase(KEYWORD_EXTENDED))
 			return new PatchDHEExtendedContext();
+		else if (matchIdentifierLexemeIgnoreCase(KEYWORD_MBF21))
+			return new PatchMBF21Context();
 		else
 		{
-			addErrorMessage("Expected valid patch format type (%s, %s, %s, %s, %s).", 
-				KEYWORD_DOOM19, KEYWORD_UDOOM19, KEYWORD_BOOM, KEYWORD_MBF, KEYWORD_EXTENDED
+			addErrorMessage("Expected valid patch format type (%s, %s, %s, %s, %s, %s).", 
+				KEYWORD_DOOM19, KEYWORD_UDOOM19, KEYWORD_BOOM, KEYWORD_MBF, KEYWORD_EXTENDED, KEYWORD_MBF21
 			);
 			return null;
 		}
@@ -1880,7 +1884,7 @@ public final class DecoHackParser extends Lexer.Parser
 		{
 			useOffsets = matchOffsetDirective();
 		}
-		else if (!(context instanceof PatchMBFContext) && !(context instanceof PatchDHEExtendedContext) && state.action.isMBF())
+		else if (!(context instanceof PatchMBFContext) && !(context instanceof PatchDHEExtendedContext) && !(context instanceof PatchMBF21Context) && state.action.isMBF())
 		{
 			addErrorMessage("MBF action pointer used: " + state.action.getMnemonic() +". Patch is not MBF or better.");
 			return false;

--- a/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/DecoHackParser.java
@@ -128,6 +128,7 @@ public final class DecoHackParser extends Lexer.Parser
 	
 	private static final String KEYWORD_WEAPON = "weapon";
 	private static final String KEYWORD_AMMOTYPE = "ammotype";
+	private static final String KEYWORD_AMMOPERSHOT = "ammopershot";
 	private static final String KEYWORD_WEAPONSTATE_READY = DEHWeapon.STATE_LABEL_READY;
 	private static final String KEYWORD_WEAPONSTATE_SELECT = DEHWeapon.STATE_LABEL_SELECT;
 	private static final String KEYWORD_WEAPONSTATE_DESELECT = DEHWeapon.STATE_LABEL_DESELECT;
@@ -1345,9 +1346,22 @@ public final class DecoHackParser extends Lexer.Parser
 
 				weapon.setAmmoType(ammo);
 			}
+			else if (matchIdentifierLexemeIgnoreCase(KEYWORD_AMMOPERSHOT))
+			{
+				Integer ammoPerShot;
+				if ((ammoPerShot = matchPositiveInteger()) == null)
+				{
+					addErrorMessage("Expected ammo per shot: a positive integer.");
+					return false;
+				}
+				else
+				{
+					weapon.setAmmoPerShot(ammoPerShot);
+				}
+			}
 			else
 			{
-				addErrorMessage("Expected '%s', '%s', or state block start.", KEYWORD_AMMOTYPE, KEYWORD_STATE);
+				addErrorMessage("Expected '%s', '%s', '%s', or state block start.", KEYWORD_AMMOTYPE, KEYWORD_AMMOPERSHOT, KEYWORD_STATE);
 				return false;
 			}
 		}		

--- a/src/main/java/net/mtrop/doom/tools/decohack/contexts/AbstractPatchContext.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/contexts/AbstractPatchContext.java
@@ -7,6 +7,7 @@ package net.mtrop.doom.tools.decohack.contexts;
 
 import net.mtrop.doom.tools.common.Common;
 import net.mtrop.doom.tools.decohack.data.DEHActionPointer;
+import net.mtrop.doom.tools.decohack.data.DEHActionPointerType;
 import net.mtrop.doom.tools.decohack.data.DEHAmmo;
 import net.mtrop.doom.tools.decohack.data.DEHMiscellany;
 import net.mtrop.doom.tools.decohack.data.DEHSound;
@@ -173,6 +174,13 @@ public abstract class AbstractPatchContext<P extends DEHPatch> implements DEHPat
 	{
 		return Common.arrayElement(pointers, index);
 	}
+
+	/**
+	 * Checks if the given action pointer type is supported by this patch context.
+	 * @param DEHActionPointerType the action pointer type to check.
+	 * @return true if so, false if not.
+	 */
+	public abstract boolean isActionPointerTypeSupported(DEHActionPointerType type);
 
 	/**
 	 * Sets the pointer at an action pointer index.

--- a/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchBoomContext.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchBoomContext.java
@@ -5,6 +5,7 @@
  ******************************************************************************/
 package net.mtrop.doom.tools.decohack.contexts;
 
+import net.mtrop.doom.tools.decohack.data.DEHActionPointerType;
 import net.mtrop.doom.tools.decohack.patches.DEHPatchBoom;
 import net.mtrop.doom.tools.decohack.patches.PatchBoom;
 
@@ -22,4 +23,9 @@ public class PatchBoomContext extends AbstractPatchBoomContext
 		return BOOMPATCH;
 	}
 
+	@Override
+	public boolean isActionPointerTypeSupported(DEHActionPointerType type)
+	{
+		return type == DEHActionPointerType.DOOM19;
+	}
 }

--- a/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchDHEExtendedContext.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchDHEExtendedContext.java
@@ -5,6 +5,7 @@
  ******************************************************************************/
 package net.mtrop.doom.tools.decohack.contexts;
 
+import net.mtrop.doom.tools.decohack.data.DEHActionPointerType;
 import net.mtrop.doom.tools.decohack.patches.DEHPatchBoom;
 import net.mtrop.doom.tools.decohack.patches.PatchDHEExtended;
 
@@ -22,4 +23,9 @@ public class PatchDHEExtendedContext extends AbstractPatchBoomContext
 		return DHEEXTENDEDPATCH;
 	}
 
+	@Override
+	public boolean isActionPointerTypeSupported(DEHActionPointerType type)
+	{
+		return type == DEHActionPointerType.DOOM19 || type == DEHActionPointerType.MBF;
+	}
 }

--- a/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchDoom19Context.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchDoom19Context.java
@@ -5,6 +5,7 @@
  ******************************************************************************/
 package net.mtrop.doom.tools.decohack.contexts;
 
+import net.mtrop.doom.tools.decohack.data.DEHActionPointerType;
 import net.mtrop.doom.tools.decohack.patches.DEHPatchDoom19;
 import net.mtrop.doom.tools.decohack.patches.PatchDoom19;
 
@@ -20,6 +21,12 @@ public class PatchDoom19Context extends AbstractPatchDoom19Context
 	public DEHPatchDoom19 getSourcePatch()
 	{
 		return DOOM19PATCH;
+	}
+
+	@Override
+	public boolean isActionPointerTypeSupported(DEHActionPointerType type)
+	{
+		return type == DEHActionPointerType.DOOM19;
 	}
 
 	/**

--- a/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchMBF21Context.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchMBF21Context.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2020-2021 Matt Tropiano & Xaser Acheron
+ * This program and the accompanying materials are made available under 
+ * the terms of the MIT License, which accompanies this distribution.
+ ******************************************************************************/
+package net.mtrop.doom.tools.decohack.contexts;
+
+import net.mtrop.doom.tools.decohack.patches.DEHPatchBoom;
+import net.mtrop.doom.tools.decohack.patches.PatchMBF21;
+
+/**
+ * Patch context for MBF21.
+ * @author Xaser Acheron
+ */
+public class PatchMBF21Context extends AbstractPatchBoomContext
+{
+	private static final DEHPatchBoom MBF21PATCH = new PatchMBF21();
+	
+	@Override
+	public DEHPatchBoom getSourcePatch()
+	{
+		return MBF21PATCH;
+	}
+
+}

--- a/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchMBF21Context.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchMBF21Context.java
@@ -5,6 +5,7 @@
  ******************************************************************************/
 package net.mtrop.doom.tools.decohack.contexts;
 
+import net.mtrop.doom.tools.decohack.data.DEHActionPointerType;
 import net.mtrop.doom.tools.decohack.patches.DEHPatchBoom;
 import net.mtrop.doom.tools.decohack.patches.PatchMBF21;
 
@@ -20,6 +21,12 @@ public class PatchMBF21Context extends AbstractPatchBoomContext
 	public DEHPatchBoom getSourcePatch()
 	{
 		return MBF21PATCH;
+	}
+
+	@Override
+	public boolean isActionPointerTypeSupported(DEHActionPointerType type)
+	{
+		return type == DEHActionPointerType.DOOM19 || type == DEHActionPointerType.MBF || type == DEHActionPointerType.MBF21;
 	}
 
 }

--- a/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchMBFContext.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchMBFContext.java
@@ -5,6 +5,7 @@
  ******************************************************************************/
 package net.mtrop.doom.tools.decohack.contexts;
 
+import net.mtrop.doom.tools.decohack.data.DEHActionPointerType;
 import net.mtrop.doom.tools.decohack.patches.DEHPatchBoom;
 import net.mtrop.doom.tools.decohack.patches.PatchMBF;
 
@@ -22,4 +23,9 @@ public class PatchMBFContext extends AbstractPatchBoomContext
 		return MBFPATCH;
 	}
 
+	@Override
+	public boolean isActionPointerTypeSupported(DEHActionPointerType type)
+	{
+		return type == DEHActionPointerType.DOOM19 || type == DEHActionPointerType.MBF;
+	}
 }

--- a/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchUltimateDoom19Context.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/contexts/PatchUltimateDoom19Context.java
@@ -5,6 +5,7 @@
  ******************************************************************************/
 package net.mtrop.doom.tools.decohack.contexts;
 
+import net.mtrop.doom.tools.decohack.data.DEHActionPointerType;
 import net.mtrop.doom.tools.decohack.patches.DEHPatchDoom19;
 import net.mtrop.doom.tools.decohack.patches.PatchUDoom19;
 
@@ -22,7 +23,13 @@ public class PatchUltimateDoom19Context extends AbstractPatchDoom19Context
 	{
 		return UDOOM19PATCH;
 	}
-	
+
+	@Override
+	public boolean isActionPointerTypeSupported(DEHActionPointerType type)
+	{
+		return type == DEHActionPointerType.DOOM19;
+	}
+
 	/**
 	 * @return the string offset for sound names, or null if not supported.
 	 */

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointer.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointer.java
@@ -96,14 +96,14 @@ public enum DEHActionPointer
 	// MBF Action Pointers
 	
 	DETONATE        (-1, "Detonate", DEHActionPointerType.MBF ),
-	MUSHROOM        (-1, "Mushroom", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.ANGLE_FIXED, DEHActionPointerParam.INT } ), // fixed point on both
-	SPAWN           (-1, "Spawn", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.INT } ),
-	TURN            (-1, "Turn", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.ANGLE_INT } ),
-	FACE            (-1, "Face", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.ANGLE_UINT } ),
-	SCRATCH         (-1, "Scratch", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.SHORT, DEHActionPointerParam.UINT } ),
-	PLAYSOUND       (-1, "PlaySound", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL } ),
-	RANDOMJUMP      (-1, "RandomJump", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.BYTE } ),
-	LINEEFFECT      (-1, "LineEffect", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.SHORT, DEHActionPointerParam.SHORT } ),
+	MUSHROOM        (-1, "Mushroom", DEHActionPointerType.MBF, DEHActionPointerParam.ANGLE_FIXED, DEHActionPointerParam.INT ), // fixed point on both
+	SPAWN           (-1, "Spawn", DEHActionPointerType.MBF, DEHActionPointerParam.UINT, DEHActionPointerParam.INT ),
+	TURN            (-1, "Turn", DEHActionPointerType.MBF, DEHActionPointerParam.ANGLE_INT ),
+	FACE            (-1, "Face", DEHActionPointerType.MBF, DEHActionPointerParam.ANGLE_UINT ),
+	SCRATCH         (-1, "Scratch", DEHActionPointerType.MBF, DEHActionPointerParam.SHORT, DEHActionPointerParam.UINT ),
+	PLAYSOUND       (-1, "PlaySound", DEHActionPointerType.MBF, DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL ),
+	RANDOMJUMP      (-1, "RandomJump", DEHActionPointerType.MBF, DEHActionPointerParam.UINT, DEHActionPointerParam.BYTE ),
+	LINEEFFECT      (-1, "LineEffect", DEHActionPointerType.MBF, DEHActionPointerParam.SHORT, DEHActionPointerParam.SHORT ),
 	DIE             (-1, "Die", DEHActionPointerType.MBF ),
 	FIREOLDBFG      (-1, "FireOldBFG", DEHActionPointerType.MBF ),
 	BETASKULLATTACK (-1, "BetaSkullAttack", DEHActionPointerType.MBF ),
@@ -111,18 +111,18 @@ public enum DEHActionPointer
 
 	// MBF21 Action Pointers
 
-	SPAWNFACING         (-1, "SpawnFacing", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.INT } ),
-	MONSTERPROJECTILE   (-1, "MonsterProjectile", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.ANGLE_FIXED } ),
-	MONSTERBULLETATTACK (-1, "MonsterBulletAttack", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.SHORT, DEHActionPointerParam.ANGLE_FIXED } ),
-	RADIUSDAMAGE        (-1, "RadiusDamage", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.UINT } ),
-	WEAPONPROJECTILE    (-1, "WeaponProjectile", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.ANGLE_FIXED } ),
-	WEAPONBULLETATTACK  (-1, "WeaponBulletAttack", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.SHORT, DEHActionPointerParam.ANGLE_FIXED } ),
-	WEAPONSOUND         (-1, "WeaponSound", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL } ),
-	WEAPONJUMP          (-1, "WeaponJump", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.BYTE } ),
-	CONSUMEAMMO         (-1, "ConsumeAmmo", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.SHORT } ),
-	CHECKAMMO           (-1, "CheckAmmo", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.SHORT } ),
-	REFIRETO            (-1, "RefireTo", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL } ),
-	GUNFLASHTO          (-1, "GunFlashTo", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL } ),
+	SPAWNFACING         (-1, "SpawnFacing", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.INT ),
+	MONSTERPROJECTILE   (-1, "MonsterProjectile", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.ANGLE_FIXED ),
+	MONSTERBULLETATTACK (-1, "MonsterBulletAttack", DEHActionPointerType.MBF21, DEHActionPointerParam.SHORT, DEHActionPointerParam.ANGLE_FIXED ),
+	RADIUSDAMAGE        (-1, "RadiusDamage", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.UINT ),
+	WEAPONPROJECTILE    (-1, "WeaponProjectile", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.ANGLE_FIXED ),
+	WEAPONBULLETATTACK  (-1, "WeaponBulletAttack", DEHActionPointerType.MBF21, DEHActionPointerParam.SHORT, DEHActionPointerParam.ANGLE_FIXED ),
+	WEAPONSOUND         (-1, "WeaponSound", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL ),
+	WEAPONJUMP          (-1, "WeaponJump", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.BYTE ),
+	CONSUMEAMMO         (-1, "ConsumeAmmo", DEHActionPointerType.MBF21, DEHActionPointerParam.SHORT ),
+	CHECKAMMO           (-1, "CheckAmmo", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.SHORT ),
+	REFIRETO            (-1, "RefireTo", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL ),
+	GUNFLASHTO          (-1, "GunFlashTo", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL ),
 	;
 	
 	/** Originating frame (for DEH 3.0 format 19). */
@@ -157,7 +157,7 @@ public enum DEHActionPointer
 		this(frame, mnemonic, type, new DEHActionPointerParam[0]);
 	}
 
-	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type, DEHActionPointerParam[] params)
+	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type, DEHActionPointerParam ... params)
 	{
 		this.frame = frame;
 		this.mnemonic = mnemonic;

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointer.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointer.java
@@ -8,6 +8,8 @@ package net.mtrop.doom.tools.decohack.data;
 import java.util.Map;
 import java.util.TreeMap;
 
+import net.mtrop.doom.tools.decohack.data.DEHActionPointerType;
+
 /**
  * Enumeration of action pointers for frames.
  * @author Matthew Tropiano
@@ -92,27 +94,27 @@ public enum DEHActionPointer
 	
 	// MBF Action Pointers
 	
-	DETONATE        (-1, "Detonate", true),
-	MUSHROOM        (-1, "Mushroom", true, (-360 << 16) + 1, (360 << 16) - 1, Integer.MIN_VALUE, Integer.MAX_VALUE), // fixed point on both
-	SPAWN           (-1, "Spawn", true, 0, Integer.MAX_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE),
-	TURN            (-1, "Turn", true, -359, 359),
-	FACE            (-1, "Face", true, 0, 359),
-	SCRATCH         (-1, "Scratch", true, -32767, 32767, 0, Integer.MAX_VALUE),
-	PLAYSOUND       (-1, "PlaySound", true, 0, Integer.MAX_VALUE, 0, 1),
-	RANDOMJUMP      (-1, "RandomJump", true, 0, Integer.MAX_VALUE, 0, 255),
-	LINEEFFECT      (-1, "LineEffect", true, -32767, 32767, -32767, 32767),
-	DIE             (-1, "Die", true),
-	FIREOLDBFG      (-1, "FireOldBFG", true),
-	BETASKULLATTACK (-1, "BetaSkullAttack", true),
-	STOP            (-1, "Stop", true),	
+	DETONATE        (-1, "Detonate", DEHActionPointerType.MBF),
+	MUSHROOM        (-1, "Mushroom", DEHActionPointerType.MBF, (-360 << 16) + 1, (360 << 16) - 1, Integer.MIN_VALUE, Integer.MAX_VALUE), // fixed point on both
+	SPAWN           (-1, "Spawn", DEHActionPointerType.MBF, 0, Integer.MAX_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE),
+	TURN            (-1, "Turn", DEHActionPointerType.MBF, -359, 359),
+	FACE            (-1, "Face", DEHActionPointerType.MBF, 0, 359),
+	SCRATCH         (-1, "Scratch", DEHActionPointerType.MBF, -32767, 32767, 0, Integer.MAX_VALUE),
+	PLAYSOUND       (-1, "PlaySound", DEHActionPointerType.MBF, 0, Integer.MAX_VALUE, 0, 1),
+	RANDOMJUMP      (-1, "RandomJump", DEHActionPointerType.MBF, 0, Integer.MAX_VALUE, 0, 255),
+	LINEEFFECT      (-1, "LineEffect", DEHActionPointerType.MBF, -32767, 32767, -32767, 32767),
+	DIE             (-1, "Die", DEHActionPointerType.MBF),
+	FIREOLDBFG      (-1, "FireOldBFG", DEHActionPointerType.MBF),
+	BETASKULLATTACK (-1, "BetaSkullAttack", DEHActionPointerType.MBF),
+	STOP            (-1, "Stop", DEHActionPointerType.MBF),
 	;
 	
 	/** Originating frame (for DEH 3.0 format 19). */
 	private int frame;
 	/** Mnemonic name for BEX/DECORATE. */
 	private String mnemonic;
-	/** MBF only. */
-	private boolean mbf;
+	/** Action pointer type. */
+	private DEHActionPointerType type;
 	
 	private int param0min;
 	private int param0max;
@@ -134,24 +136,24 @@ public enum DEHActionPointer
 	
 	private DEHActionPointer(int frame, String mnemonic)
 	{
-		this(frame, mnemonic, false, 0, 0, 0, 0);
+		this(frame, mnemonic, DEHActionPointerType.DOOM19, 0, 0, 0, 0);
 	}
 
-	private DEHActionPointer(int frame, String mnemonic, boolean mbf)
+	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type)
 	{
-		this(frame, mnemonic, mbf, 0, 0, 0, 0);
+		this(frame, mnemonic, type, 0, 0, 0, 0);
 	}
 
-	private DEHActionPointer(int frame, String mnemonic, boolean mbf, int param0min, int param0max)
+	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type, int param0min, int param0max)
 	{
-		this(frame, mnemonic, mbf, param0min, param0max, 0, 0);
+		this(frame, mnemonic, type, param0min, param0max, 0, 0);
 	}
 
-	private DEHActionPointer(int frame, String mnemonic, boolean mbf, int param0min, int param0max, int param1min, int param1max)
+	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type, int param0min, int param0max, int param1min, int param1max)
 	{
 		this.frame = frame;
 		this.mnemonic = mnemonic;
-		this.mbf = mbf;
+		this.type = type;
 		this.param0min = param0min;
 		this.param0max = param0max;
 		this.param1min = param1min;
@@ -168,9 +170,9 @@ public enum DEHActionPointer
 		return mnemonic;
 	}
 	
-	public boolean isMBF() 
+	public DEHActionPointerType getType() 
 	{
-		return mbf;
+		return type;
 	}
 	
 	public int getParam0min()

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointer.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointer.java
@@ -8,6 +8,7 @@ package net.mtrop.doom.tools.decohack.data;
 import java.util.Map;
 import java.util.TreeMap;
 
+import net.mtrop.doom.tools.decohack.data.DEHActionPointerParam;
 import net.mtrop.doom.tools.decohack.data.DEHActionPointerType;
 
 /**
@@ -95,14 +96,14 @@ public enum DEHActionPointer
 	// MBF Action Pointers
 	
 	DETONATE        (-1, "Detonate", DEHActionPointerType.MBF),
-	MUSHROOM        (-1, "Mushroom", DEHActionPointerType.MBF, (-360 << 16) + 1, (360 << 16) - 1, Integer.MIN_VALUE, Integer.MAX_VALUE), // fixed point on both
-	SPAWN           (-1, "Spawn", DEHActionPointerType.MBF, 0, Integer.MAX_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE),
-	TURN            (-1, "Turn", DEHActionPointerType.MBF, -359, 359),
-	FACE            (-1, "Face", DEHActionPointerType.MBF, 0, 359),
-	SCRATCH         (-1, "Scratch", DEHActionPointerType.MBF, -32767, 32767, 0, Integer.MAX_VALUE),
-	PLAYSOUND       (-1, "PlaySound", DEHActionPointerType.MBF, 0, Integer.MAX_VALUE, 0, 1),
-	RANDOMJUMP      (-1, "RandomJump", DEHActionPointerType.MBF, 0, Integer.MAX_VALUE, 0, 255),
-	LINEEFFECT      (-1, "LineEffect", DEHActionPointerType.MBF, -32767, 32767, -32767, 32767),
+	MUSHROOM        (-1, "Mushroom", DEHActionPointerType.MBF, DEHActionPointerParam.ANGLE_FIXED, DEHActionPointerParam.INT), // fixed point on both
+	SPAWN           (-1, "Spawn", DEHActionPointerType.MBF, DEHActionPointerParam.UINT, DEHActionPointerParam.INT),
+	TURN            (-1, "Turn", DEHActionPointerType.MBF, DEHActionPointerParam.ANGLE_INT),
+	FACE            (-1, "Face", DEHActionPointerType.MBF, DEHActionPointerParam.ANGLE_UINT),
+	SCRATCH         (-1, "Scratch", DEHActionPointerType.MBF, DEHActionPointerParam.SHORT, DEHActionPointerParam.UINT),
+	PLAYSOUND       (-1, "PlaySound", DEHActionPointerType.MBF, DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL),
+	RANDOMJUMP      (-1, "RandomJump", DEHActionPointerType.MBF, DEHActionPointerParam.UINT, DEHActionPointerParam.BYTE),
+	LINEEFFECT      (-1, "LineEffect", DEHActionPointerType.MBF, DEHActionPointerParam.SHORT, DEHActionPointerParam.SHORT),
 	DIE             (-1, "Die", DEHActionPointerType.MBF),
 	FIREOLDBFG      (-1, "FireOldBFG", DEHActionPointerType.MBF),
 	BETASKULLATTACK (-1, "BetaSkullAttack", DEHActionPointerType.MBF),
@@ -110,18 +111,18 @@ public enum DEHActionPointer
 
 	// MBF21 Action Pointers
 
-	SPAWNFACING         (-1, "SpawnFacing", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE),
-	MONSTERPROJECTILE   (-1, "MonsterProjectile", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, (-360 << 16) + 1, (360 << 16) - 1),
-	MONSTERBULLETATTACK (-1, "MonsterBulletAttack", DEHActionPointerType.MBF21, -32767, 32767, (-360 << 16) + 1, (360 << 16) - 1),
-	RADIUSDAMAGE        (-1, "RadiusDamage", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, 0, Integer.MAX_VALUE),
-	WEAPONPROJECTILE    (-1, "WeaponProjectile", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, (-360 << 16) + 1, (360 << 16) - 1),
-	WEAPONBULLETATTACK  (-1, "WeaponBulletAttack", DEHActionPointerType.MBF21, -32767, 32767, (-360 << 16) + 1, (360 << 16) - 1),
-	WEAPONSOUND         (-1, "WeaponSound", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, 0, 1),
-	WEAPONJUMP          (-1, "WeaponJump", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, 0, 255),
-	CONSUMEAMMO         (-1, "ConsumeAmmo", DEHActionPointerType.MBF21, -32767, 32767),
-	CHECKAMMO           (-1, "CheckAmmo", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, -32767, 32767),
-	REFIRETO            (-1, "RefireTo", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, 0, 1),
-	GUNFLASHTO          (-1, "GunFlashTo", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, 0, 1),
+	SPAWNFACING         (-1, "SpawnFacing", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.INT),
+	MONSTERPROJECTILE   (-1, "MonsterProjectile", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.ANGLE_FIXED),
+	MONSTERBULLETATTACK (-1, "MonsterBulletAttack", DEHActionPointerType.MBF21, DEHActionPointerParam.SHORT, DEHActionPointerParam.ANGLE_FIXED),
+	RADIUSDAMAGE        (-1, "RadiusDamage", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.UINT),
+	WEAPONPROJECTILE    (-1, "WeaponProjectile", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.ANGLE_FIXED),
+	WEAPONBULLETATTACK  (-1, "WeaponBulletAttack", DEHActionPointerType.MBF21, DEHActionPointerParam.SHORT, DEHActionPointerParam.ANGLE_FIXED),
+	WEAPONSOUND         (-1, "WeaponSound", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL),
+	WEAPONJUMP          (-1, "WeaponJump", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.BYTE),
+	CONSUMEAMMO         (-1, "ConsumeAmmo", DEHActionPointerType.MBF21, DEHActionPointerParam.SHORT),
+	CHECKAMMO           (-1, "CheckAmmo", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.SHORT),
+	REFIRETO            (-1, "RefireTo", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL),
+	GUNFLASHTO          (-1, "GunFlashTo", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL),
 	;
 	
 	/** Originating frame (for DEH 3.0 format 19). */
@@ -131,10 +132,8 @@ public enum DEHActionPointer
 	/** Action pointer type. */
 	private DEHActionPointerType type;
 	
-	private int param0min;
-	private int param0max;
-	private int param1min;
-	private int param1max;
+	private DEHActionPointerParam param0;
+	private DEHActionPointerParam param1;
 
 	private static Map<String, DEHActionPointer> MNEMONIC_MAP = null;
 
@@ -151,28 +150,26 @@ public enum DEHActionPointer
 	
 	private DEHActionPointer(int frame, String mnemonic)
 	{
-		this(frame, mnemonic, DEHActionPointerType.DOOM19, 0, 0, 0, 0);
+		this(frame, mnemonic, DEHActionPointerType.DOOM19, DEHActionPointerParam.NONE, DEHActionPointerParam.NONE);
 	}
 
 	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type)
 	{
-		this(frame, mnemonic, type, 0, 0, 0, 0);
+		this(frame, mnemonic, type, DEHActionPointerParam.NONE, DEHActionPointerParam.NONE);
 	}
 
-	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type, int param0min, int param0max)
+	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type, DEHActionPointerParam param0)
 	{
-		this(frame, mnemonic, type, param0min, param0max, 0, 0);
+		this(frame, mnemonic, type, param0, DEHActionPointerParam.NONE);
 	}
 
-	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type, int param0min, int param0max, int param1min, int param1max)
+	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type, DEHActionPointerParam param0, DEHActionPointerParam param1)
 	{
 		this.frame = frame;
 		this.mnemonic = mnemonic;
 		this.type = type;
-		this.param0min = param0min;
-		this.param0max = param0max;
-		this.param1min = param1min;
-		this.param1max = param1max;
+		this.param0 = param0;
+		this.param1 = param1;
 	}
 
 	public int getFrame() 
@@ -190,24 +187,14 @@ public enum DEHActionPointer
 		return type;
 	}
 	
-	public int getParam0min()
+	public DEHActionPointerParam getParam0()
 	{
-		return param0min;
+		return param0;
 	}
-	
-	public int getParam0max() 
+
+	public DEHActionPointerParam getParam1()
 	{
-		return param0max;
-	}
-	
-	public int getParam1min()
-	{
-		return param1min;
-	}
-	
-	public int getParam1max() 
-	{
-		return param1max;
+		return param1;
 	}
 	
 }

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointer.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointer.java
@@ -95,34 +95,34 @@ public enum DEHActionPointer
 	
 	// MBF Action Pointers
 	
-	DETONATE        (-1, "Detonate", DEHActionPointerType.MBF),
-	MUSHROOM        (-1, "Mushroom", DEHActionPointerType.MBF, DEHActionPointerParam.ANGLE_FIXED, DEHActionPointerParam.INT), // fixed point on both
-	SPAWN           (-1, "Spawn", DEHActionPointerType.MBF, DEHActionPointerParam.UINT, DEHActionPointerParam.INT),
-	TURN            (-1, "Turn", DEHActionPointerType.MBF, DEHActionPointerParam.ANGLE_INT),
-	FACE            (-1, "Face", DEHActionPointerType.MBF, DEHActionPointerParam.ANGLE_UINT),
-	SCRATCH         (-1, "Scratch", DEHActionPointerType.MBF, DEHActionPointerParam.SHORT, DEHActionPointerParam.UINT),
-	PLAYSOUND       (-1, "PlaySound", DEHActionPointerType.MBF, DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL),
-	RANDOMJUMP      (-1, "RandomJump", DEHActionPointerType.MBF, DEHActionPointerParam.UINT, DEHActionPointerParam.BYTE),
-	LINEEFFECT      (-1, "LineEffect", DEHActionPointerType.MBF, DEHActionPointerParam.SHORT, DEHActionPointerParam.SHORT),
-	DIE             (-1, "Die", DEHActionPointerType.MBF),
-	FIREOLDBFG      (-1, "FireOldBFG", DEHActionPointerType.MBF),
-	BETASKULLATTACK (-1, "BetaSkullAttack", DEHActionPointerType.MBF),
-	STOP            (-1, "Stop", DEHActionPointerType.MBF),
+	DETONATE        (-1, "Detonate", DEHActionPointerType.MBF ),
+	MUSHROOM        (-1, "Mushroom", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.ANGLE_FIXED, DEHActionPointerParam.INT } ), // fixed point on both
+	SPAWN           (-1, "Spawn", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.INT } ),
+	TURN            (-1, "Turn", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.ANGLE_INT } ),
+	FACE            (-1, "Face", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.ANGLE_UINT } ),
+	SCRATCH         (-1, "Scratch", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.SHORT, DEHActionPointerParam.UINT } ),
+	PLAYSOUND       (-1, "PlaySound", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL } ),
+	RANDOMJUMP      (-1, "RandomJump", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.BYTE } ),
+	LINEEFFECT      (-1, "LineEffect", DEHActionPointerType.MBF, new DEHActionPointerParam[]{ DEHActionPointerParam.SHORT, DEHActionPointerParam.SHORT } ),
+	DIE             (-1, "Die", DEHActionPointerType.MBF ),
+	FIREOLDBFG      (-1, "FireOldBFG", DEHActionPointerType.MBF ),
+	BETASKULLATTACK (-1, "BetaSkullAttack", DEHActionPointerType.MBF ),
+	STOP            (-1, "Stop", DEHActionPointerType.MBF ),
 
 	// MBF21 Action Pointers
 
-	SPAWNFACING         (-1, "SpawnFacing", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.INT),
-	MONSTERPROJECTILE   (-1, "MonsterProjectile", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.ANGLE_FIXED),
-	MONSTERBULLETATTACK (-1, "MonsterBulletAttack", DEHActionPointerType.MBF21, DEHActionPointerParam.SHORT, DEHActionPointerParam.ANGLE_FIXED),
-	RADIUSDAMAGE        (-1, "RadiusDamage", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.UINT),
-	WEAPONPROJECTILE    (-1, "WeaponProjectile", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.ANGLE_FIXED),
-	WEAPONBULLETATTACK  (-1, "WeaponBulletAttack", DEHActionPointerType.MBF21, DEHActionPointerParam.SHORT, DEHActionPointerParam.ANGLE_FIXED),
-	WEAPONSOUND         (-1, "WeaponSound", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL),
-	WEAPONJUMP          (-1, "WeaponJump", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.BYTE),
-	CONSUMEAMMO         (-1, "ConsumeAmmo", DEHActionPointerType.MBF21, DEHActionPointerParam.SHORT),
-	CHECKAMMO           (-1, "CheckAmmo", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.SHORT),
-	REFIRETO            (-1, "RefireTo", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL),
-	GUNFLASHTO          (-1, "GunFlashTo", DEHActionPointerType.MBF21, DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL),
+	SPAWNFACING         (-1, "SpawnFacing", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.INT } ),
+	MONSTERPROJECTILE   (-1, "MonsterProjectile", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.ANGLE_FIXED } ),
+	MONSTERBULLETATTACK (-1, "MonsterBulletAttack", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.SHORT, DEHActionPointerParam.ANGLE_FIXED } ),
+	RADIUSDAMAGE        (-1, "RadiusDamage", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.UINT } ),
+	WEAPONPROJECTILE    (-1, "WeaponProjectile", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.ANGLE_FIXED } ),
+	WEAPONBULLETATTACK  (-1, "WeaponBulletAttack", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.SHORT, DEHActionPointerParam.ANGLE_FIXED } ),
+	WEAPONSOUND         (-1, "WeaponSound", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL } ),
+	WEAPONJUMP          (-1, "WeaponJump", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.BYTE } ),
+	CONSUMEAMMO         (-1, "ConsumeAmmo", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.SHORT } ),
+	CHECKAMMO           (-1, "CheckAmmo", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.SHORT } ),
+	REFIRETO            (-1, "RefireTo", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL } ),
+	GUNFLASHTO          (-1, "GunFlashTo", DEHActionPointerType.MBF21, new DEHActionPointerParam[]{ DEHActionPointerParam.UINT, DEHActionPointerParam.BOOL } ),
 	;
 	
 	/** Originating frame (for DEH 3.0 format 19). */
@@ -132,8 +132,7 @@ public enum DEHActionPointer
 	/** Action pointer type. */
 	private DEHActionPointerType type;
 	
-	private DEHActionPointerParam param0;
-	private DEHActionPointerParam param1;
+	private DEHActionPointerParam[] params;
 
 	private static Map<String, DEHActionPointer> MNEMONIC_MAP = null;
 
@@ -150,26 +149,20 @@ public enum DEHActionPointer
 	
 	private DEHActionPointer(int frame, String mnemonic)
 	{
-		this(frame, mnemonic, DEHActionPointerType.DOOM19, DEHActionPointerParam.NONE, DEHActionPointerParam.NONE);
+		this(frame, mnemonic, DEHActionPointerType.DOOM19, new DEHActionPointerParam[0]);
 	}
 
 	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type)
 	{
-		this(frame, mnemonic, type, DEHActionPointerParam.NONE, DEHActionPointerParam.NONE);
+		this(frame, mnemonic, type, new DEHActionPointerParam[0]);
 	}
 
-	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type, DEHActionPointerParam param0)
-	{
-		this(frame, mnemonic, type, param0, DEHActionPointerParam.NONE);
-	}
-
-	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type, DEHActionPointerParam param0, DEHActionPointerParam param1)
+	private DEHActionPointer(int frame, String mnemonic, DEHActionPointerType type, DEHActionPointerParam[] params)
 	{
 		this.frame = frame;
 		this.mnemonic = mnemonic;
 		this.type = type;
-		this.param0 = param0;
-		this.param1 = param1;
+		this.params = params;
 	}
 
 	public int getFrame() 
@@ -187,14 +180,9 @@ public enum DEHActionPointer
 		return type;
 	}
 	
-	public DEHActionPointerParam getParam0()
+	public DEHActionPointerParam[] getParams()
 	{
-		return param0;
-	}
-
-	public DEHActionPointerParam getParam1()
-	{
-		return param1;
+		return params;
 	}
 
 	public boolean useArgs()

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointer.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointer.java
@@ -107,6 +107,21 @@ public enum DEHActionPointer
 	FIREOLDBFG      (-1, "FireOldBFG", DEHActionPointerType.MBF),
 	BETASKULLATTACK (-1, "BetaSkullAttack", DEHActionPointerType.MBF),
 	STOP            (-1, "Stop", DEHActionPointerType.MBF),
+
+	// MBF21 Action Pointers
+
+	SPAWNFACING         (-1, "SpawnFacing", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE),
+	MONSTERPROJECTILE   (-1, "MonsterProjectile", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, (-360 << 16) + 1, (360 << 16) - 1),
+	MONSTERBULLETATTACK (-1, "MonsterBulletAttack", DEHActionPointerType.MBF21, -32767, 32767, (-360 << 16) + 1, (360 << 16) - 1),
+	RADIUSDAMAGE        (-1, "RadiusDamage", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, 0, Integer.MAX_VALUE),
+	WEAPONPROJECTILE    (-1, "WeaponProjectile", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, (-360 << 16) + 1, (360 << 16) - 1),
+	WEAPONBULLETATTACK  (-1, "WeaponBulletAttack", DEHActionPointerType.MBF21, -32767, 32767, (-360 << 16) + 1, (360 << 16) - 1),
+	WEAPONSOUND         (-1, "WeaponSound", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, 0, 1),
+	WEAPONJUMP          (-1, "WeaponJump", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, 0, 255),
+	CONSUMEAMMO         (-1, "ConsumeAmmo", DEHActionPointerType.MBF21, -32767, 32767),
+	CHECKAMMO           (-1, "CheckAmmo", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, -32767, 32767),
+	REFIRETO            (-1, "RefireTo", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, 0, 1),
+	GUNFLASHTO          (-1, "GunFlashTo", DEHActionPointerType.MBF21, 0, Integer.MAX_VALUE, 0, 1),
 	;
 	
 	/** Originating frame (for DEH 3.0 format 19). */

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointer.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointer.java
@@ -196,5 +196,10 @@ public enum DEHActionPointer
 	{
 		return param1;
 	}
+
+	public boolean useArgs()
+	{
+		return type != null && type.getUseArgs();
+	}
 	
 }

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointerParam.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointerParam.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020-2021 Matt Tropiano & Xaser Acheron
+ * This program and the accompanying materials are made available under 
+ * the terms of the MIT License, which accompanies this distribution.
+ ******************************************************************************/
+package net.mtrop.doom.tools.decohack.data;
+
+/**
+ * Enumeration of action pointer parameter types.
+ * @author Xaser Acheron
+ */
+public enum DEHActionPointerParam
+{
+	NONE(0, 0),
+	BOOL(0, 1),
+	BYTE(0, 255),
+	SHORT(-32767, 32767),
+	INT(Integer.MIN_VALUE, Integer.MAX_VALUE),
+	UINT(0, Integer.MAX_VALUE),
+	ANGLE_INT(-359, 359),
+	ANGLE_UINT(0, 359),
+	ANGLE_FIXED((-360 << 16) + 1, (360 << 16) - 1),
+	;
+
+	private int valueMin;
+	private int valueMax;
+
+	private DEHActionPointerParam(int valueMin, int valueMax)
+	{
+		this.valueMin = valueMin;
+		this.valueMax = valueMax;
+	}
+
+	public int getValueMin()
+	{
+		return valueMin;
+	}
+
+	public int getValueMax()
+	{
+		return valueMax;
+	}
+
+	public boolean isValueValid(int value)
+	{
+		return value >= valueMin && value <= valueMax;
+	}
+}

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointerType.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointerType.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2020-2021 Matt Tropiano & Xaser Acheron
+ * This program and the accompanying materials are made available under 
+ * the terms of the MIT License, which accompanies this distribution.
+ ******************************************************************************/
+package net.mtrop.doom.tools.decohack.data;
+
+/**
+ * Enumeration of action pointer types.
+ * @author Xaser Acheron
+ */
+public enum DEHActionPointerType
+{
+	DOOM19,
+	MBF,
+	MBF21;
+
+	public static final DEHActionPointerType[] VALUES = values();
+}

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointerType.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHActionPointerType.java
@@ -11,9 +11,21 @@ package net.mtrop.doom.tools.decohack.data;
  */
 public enum DEHActionPointerType
 {
-	DOOM19,
-	MBF,
-	MBF21;
+	DOOM19(false),
+	MBF(false),
+	MBF21(true);
 
 	public static final DEHActionPointerType[] VALUES = values();
+
+	private boolean useArgs;
+
+	private DEHActionPointerType(boolean useArgs)
+	{
+		this.useArgs = useArgs;
+	}
+
+	public boolean getUseArgs()
+	{
+		return useArgs;
+	}
 }

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHState.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHState.java
@@ -7,6 +7,8 @@ package net.mtrop.doom.tools.decohack.data;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Arrays;
+import java.util.LinkedList;
 
 import net.mtrop.doom.util.RangeUtils;
 
@@ -23,6 +25,7 @@ public class DEHState implements DEHObject<DEHState>
 	private int duration;
 	private int misc1;
 	private int misc2;
+	private int[] args;
 	
 	/**
 	 * Creates a new frame.
@@ -36,16 +39,17 @@ public class DEHState implements DEHObject<DEHState>
 			0, 
 			-1,
 			0,
-			0
+			0,
+			new int[0]
 		);
 	}
 	
 	public static DEHState create(int spriteIndex, int frameIndex, boolean bright, int nextStateIndex, int duration)
 	{
-		return create(spriteIndex, frameIndex, bright, nextStateIndex, duration, 0, 0);
+		return create(spriteIndex, frameIndex, bright, nextStateIndex, duration, 0, 0, new int[0]);
 	}
 
-	public static DEHState create(int spriteIndex, int frameIndex, boolean bright, int nextStateIndex, int duration, int misc1, int misc2)
+	public static DEHState create(int spriteIndex, int frameIndex, boolean bright, int nextStateIndex, int duration, int misc1, int misc2, int[] args)
 	{
 		return (new DEHState()).set(
 			spriteIndex,
@@ -54,7 +58,8 @@ public class DEHState implements DEHObject<DEHState>
 			nextStateIndex, 
 			duration,
 			misc1,
-			misc2
+			misc2,
+			args
 		);
 	}
 
@@ -68,16 +73,17 @@ public class DEHState implements DEHObject<DEHState>
 			source.nextStateIndex, 
 			source.duration, 
 			source.misc1, 
-			source.misc2
+			source.misc2,
+			source.args
 		);
 	}
 	
 	public DEHState set(int spriteIndex, int frameIndex, boolean bright, int nextStateIndex, int duration)
 	{
-		return set(spriteIndex, frameIndex, bright, nextStateIndex, duration, 0, 0);
+		return set(spriteIndex, frameIndex, bright, nextStateIndex, duration, 0, 0, new int[0]);
 	}
 	
-	public DEHState set(int spriteIndex, int frameIndex, boolean bright, int nextStateIndex, int duration, int misc1, int misc2)
+	public DEHState set(int spriteIndex, int frameIndex, boolean bright, int nextStateIndex, int duration, int misc1, int misc2, int[] args)
 	{
 		setSpriteIndex(spriteIndex);
 		setFrameIndex(frameIndex);
@@ -86,6 +92,7 @@ public class DEHState implements DEHObject<DEHState>
 		setDuration(duration);
 		setMisc1(misc1);
 		setMisc2(misc2);
+		setArgs(args);
 		return this;
 	}
 	
@@ -170,6 +177,29 @@ public class DEHState implements DEHObject<DEHState>
 		return this;
 	}
 	
+	public int[] getArgs()
+	{
+		return args;
+	}
+	
+	public DEHState setArgs(int[] args)
+	{
+		this.args = args;
+		return this;
+	}
+
+	public DEHState setArgs(LinkedList<Integer> arglist)
+	{
+		// gotta do this manually, 'cause unboxing, yuck :P
+		this.args = new int[arglist.size()];
+		int i = 0;
+		for (Integer arg : arglist) {
+			this.args[i] = arg;
+			i++;
+		}
+		return this;
+	}
+	
 	@Override
 	public boolean equals(Object obj) 
 	{
@@ -187,6 +217,7 @@ public class DEHState implements DEHObject<DEHState>
 			&& duration == obj.duration
 			&& misc1 == obj.misc1
 			&& misc2 == obj.misc2
+			&& Arrays.equals(args, obj.args)
 		;
 	}	
 		
@@ -205,6 +236,9 @@ public class DEHState implements DEHObject<DEHState>
 			writer.append("Unknown 1 = ").append(String.valueOf(misc1)).append("\r\n");
 		if (misc2 != frame.misc2)
 			writer.append("Unknown 2 = ").append(String.valueOf(misc2)).append("\r\n");
+		for(int i = 0; i < args.length; i++)
+			if((i >= frame.args.length || args[i] != frame.args[i]) && args[i] != 0) // [XA] skip zeroes, since mbf21 args explicitly use 0 as the default
+				writer.append("Args").append(String.valueOf(i+1)).append(" = ").append(String.valueOf(args[i])).append("\r\n");
 		writer.flush();
 	}
 

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHState.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHState.java
@@ -8,7 +8,7 @@ package net.mtrop.doom.tools.decohack.data;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
-import java.util.LinkedList;
+import java.util.List;
 
 import net.mtrop.doom.util.RangeUtils;
 
@@ -188,7 +188,7 @@ public class DEHState implements DEHObject<DEHState>
 		return this;
 	}
 
-	public DEHState setArgs(LinkedList<Integer> arglist)
+	public DEHState setArgs(List<Integer> arglist)
 	{
 		// gotta do this manually, 'cause unboxing, yuck :P
 		this.args = new int[arglist.size()];

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHState.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHState.java
@@ -193,7 +193,8 @@ public class DEHState implements DEHObject<DEHState>
 		// gotta do this manually, 'cause unboxing, yuck :P
 		this.args = new int[arglist.size()];
 		int i = 0;
-		for (Integer arg : arglist) {
+		for (Integer arg : arglist)
+		{
 			this.args[i] = arg;
 			i++;
 		}
@@ -236,8 +237,8 @@ public class DEHState implements DEHObject<DEHState>
 			writer.append("Unknown 1 = ").append(String.valueOf(misc1)).append("\r\n");
 		if (misc2 != frame.misc2)
 			writer.append("Unknown 2 = ").append(String.valueOf(misc2)).append("\r\n");
-		for(int i = 0; i < args.length; i++)
-			if((i >= frame.args.length || args[i] != frame.args[i]) && args[i] != 0) // [XA] skip zeroes, since mbf21 args explicitly use 0 as the default
+		for (int i = 0; i < args.length; i++)
+			if ((i >= frame.args.length || args[i] != frame.args[i]) && args[i] != 0) // [XA] skip zeroes, since mbf21 args explicitly use 0 as the default
 				writer.append("Args").append(String.valueOf(i+1)).append(" = ").append(String.valueOf(args[i])).append("\r\n");
 		writer.flush();
 	}

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHState.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHState.java
@@ -21,8 +21,8 @@ public class DEHState implements DEHObject<DEHState>
 	private boolean bright;
 	private int nextStateIndex;
 	private int duration;
-	private int parameter0;
-	private int parameter1;
+	private int misc1;
+	private int misc2;
 	
 	/**
 	 * Creates a new frame.
@@ -45,7 +45,7 @@ public class DEHState implements DEHObject<DEHState>
 		return create(spriteIndex, frameIndex, bright, nextStateIndex, duration, 0, 0);
 	}
 
-	public static DEHState create(int spriteIndex, int frameIndex, boolean bright, int nextStateIndex, int duration, int parameter0, int parameter1)
+	public static DEHState create(int spriteIndex, int frameIndex, boolean bright, int nextStateIndex, int duration, int misc1, int misc2)
 	{
 		return (new DEHState()).set(
 			spriteIndex,
@@ -53,8 +53,8 @@ public class DEHState implements DEHObject<DEHState>
 			bright,
 			nextStateIndex, 
 			duration,
-			parameter0,
-			parameter1
+			misc1,
+			misc2
 		);
 	}
 
@@ -67,8 +67,8 @@ public class DEHState implements DEHObject<DEHState>
 			source.bright, 
 			source.nextStateIndex, 
 			source.duration, 
-			source.parameter0, 
-			source.parameter1
+			source.misc1, 
+			source.misc2
 		);
 	}
 	
@@ -77,15 +77,15 @@ public class DEHState implements DEHObject<DEHState>
 		return set(spriteIndex, frameIndex, bright, nextStateIndex, duration, 0, 0);
 	}
 	
-	public DEHState set(int spriteIndex, int frameIndex, boolean bright, int nextStateIndex, int duration, int parameter0, int parameter1)
+	public DEHState set(int spriteIndex, int frameIndex, boolean bright, int nextStateIndex, int duration, int misc1, int misc2)
 	{
 		setSpriteIndex(spriteIndex);
 		setFrameIndex(frameIndex);
 		setBright(bright);
 		setNextStateIndex(nextStateIndex);
 		setDuration(duration);
-		setParameter0(parameter0);
-		setParameter1(parameter1);
+		setMisc1(misc1);
+		setMisc2(misc2);
 		return this;
 	}
 	
@@ -148,25 +148,25 @@ public class DEHState implements DEHObject<DEHState>
 		return this;
 	}
 	
-	public int getParameter0() 
+	public int getMisc1() 
 	{
-		return parameter0;
+		return misc1;
 	}
 	
-	public DEHState setParameter0(int parameter0) 
+	public DEHState setMisc1(int misc1) 
 	{
-		this.parameter0 = parameter0;
+		this.misc1 = misc1;
 		return this;
 	}
 	
-	public int getParameter1()
+	public int getMisc2()
 	{
-		return parameter1;
+		return misc2;
 	}
 	
-	public DEHState setParameter1(int parameter1)
+	public DEHState setMisc2(int misc2)
 	{
-		this.parameter1 = parameter1;
+		this.misc2 = misc2;
 		return this;
 	}
 	
@@ -185,8 +185,8 @@ public class DEHState implements DEHObject<DEHState>
 			&& bright == obj.bright
 			&& nextStateIndex == obj.nextStateIndex
 			&& duration == obj.duration
-			&& parameter0 == obj.parameter0
-			&& parameter1 == obj.parameter1
+			&& misc1 == obj.misc1
+			&& misc2 == obj.misc2
 		;
 	}	
 		
@@ -201,10 +201,10 @@ public class DEHState implements DEHObject<DEHState>
 			writer.append("Next frame = ").append(String.valueOf(nextStateIndex)).append("\r\n");
 		if (duration != frame.duration)
 			writer.append("Duration = ").append(String.valueOf(duration)).append("\r\n");
-		if (parameter0 != frame.parameter0)
-			writer.append("Unknown 1 = ").append(String.valueOf(parameter0)).append("\r\n");
-		if (parameter1 != frame.parameter1)
-			writer.append("Unknown 2 = ").append(String.valueOf(parameter1)).append("\r\n");
+		if (misc1 != frame.misc1)
+			writer.append("Unknown 1 = ").append(String.valueOf(misc1)).append("\r\n");
+		if (misc2 != frame.misc2)
+			writer.append("Unknown 2 = ").append(String.valueOf(misc2)).append("\r\n");
 		writer.flush();
 	}
 

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHWeapon.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHWeapon.java
@@ -43,6 +43,9 @@ public class DEHWeapon implements DEHObject<DEHWeapon>, DEHActor
 	
 	/** Ammo type. */
 	private Ammo ammoType;
+	
+	/** Ammo per shot. */
+	private int ammoPerShot;
 
 	/** State indices (label name to index). */
 	private Map<String, Integer> stateIndexMap;
@@ -53,6 +56,7 @@ public class DEHWeapon implements DEHObject<DEHWeapon>, DEHActor
 
 		setName("");
 		setAmmoType(null);
+		setAmmoPerShot(-1);
 		clearLabels();
 	}
 	
@@ -67,7 +71,7 @@ public class DEHWeapon implements DEHObject<DEHWeapon>, DEHActor
 	 * @param flash the muzzle flash index.
 	 * @return a weapon entry.
 	 */
-	public static DEHWeapon create(String name, Ammo ammo, int raise, int lower, int ready, int fire, int flash)
+	public static DEHWeapon create(String name, Ammo ammo, int raise, int lower, int ready, int fire, int flash, int ammoPerShot)
 	{
 		DEHWeapon out = new DEHWeapon(); 
 		out.setName(name);
@@ -78,6 +82,7 @@ public class DEHWeapon implements DEHObject<DEHWeapon>, DEHActor
 		out.setReadyFrameIndex(ready);
 		out.setFireFrameIndex(fire);
 		out.setFlashFrameIndex(flash);
+		out.setAmmoPerShot(ammoPerShot);
 		return out;
 	}
 	
@@ -86,6 +91,7 @@ public class DEHWeapon implements DEHObject<DEHWeapon>, DEHActor
 	{
 		setName(source.name);
 		setAmmoType(source.ammoType);
+		setAmmoPerShot(source.ammoPerShot);
 		clearLabels();
 		for (String label : source.getLabels())
 			setLabel(label, source.getLabel(label));
@@ -127,6 +133,25 @@ public class DEHWeapon implements DEHObject<DEHWeapon>, DEHActor
 	public DEHWeapon setAmmoType(Ammo ammoType) 
 	{
 		this.ammoType = ammoType;
+		return this;
+	}
+	
+	/**
+	 * @return the ammo per shot.
+	 */
+	public int getAmmoPerShot() 
+	{
+		return ammoPerShot;
+	}
+	
+	/**
+	 * Sets the ammo per shot.
+	 * @param ammoPerShot the ammo per shot.
+	 * @return this object.
+	 */
+	public DEHWeapon setAmmoPerShot(int ammoPerShot) 
+	{
+		this.ammoPerShot = ammoPerShot;
 		return this;
 	}
 	
@@ -276,6 +301,7 @@ public class DEHWeapon implements DEHObject<DEHWeapon>, DEHActor
 	public boolean equals(DEHWeapon obj) 
 	{
 		return ammoType == obj.ammoType
+			&& ammoPerShot == obj.ammoPerShot
 			&& getRaiseFrameIndex() == obj.getRaiseFrameIndex()
 			&& getLowerFrameIndex() == obj.getLowerFrameIndex()
 			&& getReadyFrameIndex() == obj.getReadyFrameIndex()
@@ -302,6 +328,9 @@ public class DEHWeapon implements DEHObject<DEHWeapon>, DEHActor
 			writer.append("Shooting frame = ").append(String.valueOf(getFireFrameIndex())).append("\r\n");
 		if (getFlashFrameIndex() != weapon.getFlashFrameIndex())
 			writer.append("Firing frame = ").append(String.valueOf(getFlashFrameIndex())).append("\r\n");
+
+		if (ammoPerShot != weapon.ammoPerShot)
+			writer.append("Ammo per shot = ").append(String.valueOf(ammoPerShot)).append("\r\n");
 		writer.flush();
 	}
 

--- a/src/main/java/net/mtrop/doom/tools/decohack/data/DEHWeapon.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/data/DEHWeapon.java
@@ -26,6 +26,8 @@ public class DEHWeapon implements DEHObject<DEHWeapon>, DEHActor
 	public static final String STATE_LABEL_FLASH = "flash";
 	public static final String STATE_LABEL_LIGHTDONE = "lightdone";
 
+	public static final int DEFAULT_AMMO_PER_SHOT = -1;
+
 	public static enum Ammo
 	{
 		BULLETS,
@@ -56,7 +58,7 @@ public class DEHWeapon implements DEHObject<DEHWeapon>, DEHActor
 
 		setName("");
 		setAmmoType(null);
-		setAmmoPerShot(-1);
+		setAmmoPerShot(DEFAULT_AMMO_PER_SHOT);
 		clearLabels();
 	}
 	

--- a/src/main/java/net/mtrop/doom/tools/decohack/patches/Constants.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/patches/Constants.java
@@ -1003,15 +1003,15 @@ interface Constants
 
 	static final DEHWeapon[] DEHWEAPON = 
 	{
-		DEHWeapon.create("Fist",            Ammo.INFINITE, S_PUNCHUP, S_PUNCHDOWN, S_PUNCH, S_PUNCH1, S_NULL, -1),
-		DEHWeapon.create("Pistol",          Ammo.BULLETS,  S_PISTOLUP, S_PISTOLDOWN, S_PISTOL, S_PISTOL1, S_PISTOLFLASH, -1),
-		DEHWeapon.create("Shotgun",         Ammo.SHELLS,   S_SGUNUP, S_SGUNDOWN, S_SGUN, S_SGUN1, S_SGUNFLASH1, -1),
-		DEHWeapon.create("Chaingun",        Ammo.BULLETS,  S_CHAINUP, S_CHAINDOWN, S_CHAIN, S_CHAIN1, S_CHAINFLASH1, -1),
-		DEHWeapon.create("Rocket launcher", Ammo.ROCKETS,  S_MISSILEUP, S_MISSILEDOWN, S_MISSILE, S_MISSILE1, S_MISSILEFLASH1, -1),
-		DEHWeapon.create("Plasma rifle",    Ammo.CELLS,    S_PLASMAUP, S_PLASMADOWN, S_PLASMA, S_PLASMA1, S_PLASMAFLASH1, -1),
-		DEHWeapon.create("BFG9000",         Ammo.CELLS,    S_BFGUP, S_BFGDOWN, S_BFG, S_BFG1, S_BFGFLASH1, -1),
-		DEHWeapon.create("Chainsaw",        Ammo.INFINITE, S_SAWUP, S_SAWDOWN, S_SAW, S_SAW1, S_NULL, -1),
-		DEHWeapon.create("Super-shotgun",   Ammo.SHELLS,   S_DSGUNUP, S_DSGUNDOWN, S_DSGUN, S_DSGUN1, S_DSGUNFLASH1, -1)
+		DEHWeapon.create("Fist",            Ammo.INFINITE, S_PUNCHUP, S_PUNCHDOWN, S_PUNCH, S_PUNCH1, S_NULL, DEHWeapon.DEFAULT_AMMO_PER_SHOT),
+		DEHWeapon.create("Pistol",          Ammo.BULLETS,  S_PISTOLUP, S_PISTOLDOWN, S_PISTOL, S_PISTOL1, S_PISTOLFLASH, DEHWeapon.DEFAULT_AMMO_PER_SHOT),
+		DEHWeapon.create("Shotgun",         Ammo.SHELLS,   S_SGUNUP, S_SGUNDOWN, S_SGUN, S_SGUN1, S_SGUNFLASH1, DEHWeapon.DEFAULT_AMMO_PER_SHOT),
+		DEHWeapon.create("Chaingun",        Ammo.BULLETS,  S_CHAINUP, S_CHAINDOWN, S_CHAIN, S_CHAIN1, S_CHAINFLASH1, DEHWeapon.DEFAULT_AMMO_PER_SHOT),
+		DEHWeapon.create("Rocket launcher", Ammo.ROCKETS,  S_MISSILEUP, S_MISSILEDOWN, S_MISSILE, S_MISSILE1, S_MISSILEFLASH1, DEHWeapon.DEFAULT_AMMO_PER_SHOT),
+		DEHWeapon.create("Plasma rifle",    Ammo.CELLS,    S_PLASMAUP, S_PLASMADOWN, S_PLASMA, S_PLASMA1, S_PLASMAFLASH1, DEHWeapon.DEFAULT_AMMO_PER_SHOT),
+		DEHWeapon.create("BFG9000",         Ammo.CELLS,    S_BFGUP, S_BFGDOWN, S_BFG, S_BFG1, S_BFGFLASH1, DEHWeapon.DEFAULT_AMMO_PER_SHOT),
+		DEHWeapon.create("Chainsaw",        Ammo.INFINITE, S_SAWUP, S_SAWDOWN, S_SAW, S_SAW1, S_NULL, DEHWeapon.DEFAULT_AMMO_PER_SHOT),
+		DEHWeapon.create("Super-shotgun",   Ammo.SHELLS,   S_DSGUNUP, S_DSGUNDOWN, S_DSGUN, S_DSGUN1, S_DSGUNFLASH1, DEHWeapon.DEFAULT_AMMO_PER_SHOT)
 	};
 
 	static final DEHSound[] DEHSOUND = 

--- a/src/main/java/net/mtrop/doom/tools/decohack/patches/Constants.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/patches/Constants.java
@@ -1003,15 +1003,15 @@ interface Constants
 
 	static final DEHWeapon[] DEHWEAPON = 
 	{
-		DEHWeapon.create("Fist",            Ammo.INFINITE, S_PUNCHUP, S_PUNCHDOWN, S_PUNCH, S_PUNCH1, S_NULL),
-		DEHWeapon.create("Pistol",          Ammo.BULLETS,  S_PISTOLUP, S_PISTOLDOWN, S_PISTOL, S_PISTOL1, S_PISTOLFLASH),
-		DEHWeapon.create("Shotgun",         Ammo.SHELLS,   S_SGUNUP, S_SGUNDOWN, S_SGUN, S_SGUN1, S_SGUNFLASH1),
-		DEHWeapon.create("Chaingun",        Ammo.BULLETS,  S_CHAINUP, S_CHAINDOWN, S_CHAIN, S_CHAIN1, S_CHAINFLASH1),
-		DEHWeapon.create("Rocket launcher", Ammo.ROCKETS,  S_MISSILEUP, S_MISSILEDOWN, S_MISSILE, S_MISSILE1, S_MISSILEFLASH1),
-		DEHWeapon.create("Plasma rifle",    Ammo.CELLS,    S_PLASMAUP, S_PLASMADOWN, S_PLASMA, S_PLASMA1, S_PLASMAFLASH1),
-		DEHWeapon.create("BFG9000",         Ammo.CELLS,    S_BFGUP, S_BFGDOWN, S_BFG, S_BFG1, S_BFGFLASH1),
-		DEHWeapon.create("Chainsaw",        Ammo.INFINITE, S_SAWUP, S_SAWDOWN, S_SAW, S_SAW1, S_NULL),
-		DEHWeapon.create("Super-shotgun",   Ammo.SHELLS,   S_DSGUNUP, S_DSGUNDOWN, S_DSGUN, S_DSGUN1, S_DSGUNFLASH1)
+		DEHWeapon.create("Fist",            Ammo.INFINITE, S_PUNCHUP, S_PUNCHDOWN, S_PUNCH, S_PUNCH1, S_NULL, -1),
+		DEHWeapon.create("Pistol",          Ammo.BULLETS,  S_PISTOLUP, S_PISTOLDOWN, S_PISTOL, S_PISTOL1, S_PISTOLFLASH, -1),
+		DEHWeapon.create("Shotgun",         Ammo.SHELLS,   S_SGUNUP, S_SGUNDOWN, S_SGUN, S_SGUN1, S_SGUNFLASH1, -1),
+		DEHWeapon.create("Chaingun",        Ammo.BULLETS,  S_CHAINUP, S_CHAINDOWN, S_CHAIN, S_CHAIN1, S_CHAINFLASH1, -1),
+		DEHWeapon.create("Rocket launcher", Ammo.ROCKETS,  S_MISSILEUP, S_MISSILEDOWN, S_MISSILE, S_MISSILE1, S_MISSILEFLASH1, -1),
+		DEHWeapon.create("Plasma rifle",    Ammo.CELLS,    S_PLASMAUP, S_PLASMADOWN, S_PLASMA, S_PLASMA1, S_PLASMAFLASH1, -1),
+		DEHWeapon.create("BFG9000",         Ammo.CELLS,    S_BFGUP, S_BFGDOWN, S_BFG, S_BFG1, S_BFGFLASH1, -1),
+		DEHWeapon.create("Chainsaw",        Ammo.INFINITE, S_SAWUP, S_SAWDOWN, S_SAW, S_SAW1, S_NULL, -1),
+		DEHWeapon.create("Super-shotgun",   Ammo.SHELLS,   S_DSGUNUP, S_DSGUNDOWN, S_DSGUN, S_DSGUN1, S_DSGUNFLASH1, -1)
 	};
 
 	static final DEHSound[] DEHSOUND = 

--- a/src/main/java/net/mtrop/doom/tools/decohack/patches/PatchMBF21.java
+++ b/src/main/java/net/mtrop/doom/tools/decohack/patches/PatchMBF21.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2020-2021 Matt Tropiano & Xaser Acheron
+ * This program and the accompanying materials are made available under 
+ * the terms of the MIT License, which accompanies this distribution.
+ ******************************************************************************/
+package net.mtrop.doom.tools.decohack.patches;
+
+/**
+ * Patch implementation for MBF21.
+ * @author Xaser Acheron
+ */
+public class PatchMBF21 extends PatchDHEExtended
+{
+	// [XA] Just a stub for now.
+}

--- a/src/main/resources/decohack/constants/mbf21.dh
+++ b/src/main/resources/decohack/constants/mbf21.dh
@@ -1,0 +1,15 @@
+#ifndef __DECOHACK_CONSTANTS_MBF21__
+#define __DECOHACK_CONSTANTS_MBF21__
+
+// Overlap with Boom for weapons/ammo.
+#include "doom19/weapons.dh"
+#include "doom19/ammo.dh"
+
+// ...but not strings...
+#include "boom/strings.dh"
+
+// ...and not states nor things
+#include "extended/states.dh"
+#include "extended/things.dh"
+
+#endif

--- a/src/main/resources/decohack/mbf21.dh
+++ b/src/main/resources/decohack/mbf21.dh
@@ -1,0 +1,10 @@
+#ifndef __DECOHACK_MBF21__
+#define __DECOHACK_MBF21__
+
+using mbf21
+
+#include "constants/mbf21.dh"
+
+state free S_FREE_START to S_FREE_END // free the "free" states immediately
+
+#endif


### PR DESCRIPTION
This is a larger chunk of work than I'd normally want to do in a single PR, but a bunch of it was some necessary stubbing of things anyway.

Quick-ish list of additions:
- Adds an `mbf21` patch type
- Adds support for MBF21's new "args" state fields
- Adds first batch of MBF21 action pointers (only usable for `mbf21` patch types)
- Adds support for the new `ammopershot` weapon field

Plenty more to be done eventually, and this is kind of a first-pass thingy, but it's all tested n' working on my side at least.