### PR TITLE
Add cygpath calls for cygwin benefit

### DIFF
--- a/src/main/resources/shell/embed/app-name.sh
+++ b/src/main/resources/shell/embed/app-name.sh
@@ -33,7 +33,11 @@ elif [ -n "${JRE_HOME}" ]; then
 fi
 
 if [[ -n "$JAVACMD" ]]; then
-	"$JAVACMD" -cp "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}" $JAVAOPTS $MAINCLASS $*
+	if [[ "$OSTYPE" == "cygwin"* ]]; then
+		"$JAVACMD" -cp "$(cygpath -w -a "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}")" $JAVAOPTS $MAINCLASS $*
+	else
+		"$JAVACMD" -cp "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}" $JAVAOPTS $MAINCLASS $*
+	fi
 else
 	echo "Java 8 or higher could not be detected. To use these tools, a JRE must be"
 	echo "installed."

--- a/src/main/resources/shell/jar/app-name.sh
+++ b/src/main/resources/shell/jar/app-name.sh
@@ -33,7 +33,11 @@ elif [ -n "${JRE_HOME}" ]; then
 fi
 
 if [[ -n "$JAVACMD" ]]; then
-	"$JAVACMD" -cp "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}" $JAVAOPTS $MAINCLASS $*
+	if [[ "$OSTYPE" == "cygwin"* ]]; then
+		"$JAVACMD" -cp "$(cygpath -w -a "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}")" $JAVAOPTS $MAINCLASS $*
+	else
+		"$JAVACMD" -cp "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}" $JAVAOPTS $MAINCLASS $*
+	fi
 else
 	echo "Java 8 or higher could not be detected. To use these tools, a JRE must be"
 	echo "installed."


### PR DESCRIPTION
When running the shell wrappers under cygwin, the path to the jar file ends up being a path to be used within cygwin, not by a `java` that is expecting a windows path.

The `cygpath` calls convert something like

`"java" -cp "/home/Dan/tmp/doomtools/jar/doomtools-2022.01.10.062403888.jar" ....`

to

`"java" -cp "C:\cygwin64\home\Dan\tmp\doomtools\jar\doomtools-2022.01.10.062403888.jar" ...`

I protected that by checking that the operating system is cygwin so this shouldn't affect other OS.