### PR TITLE
cygpath fix, settings directory

### DIFF
--- a/src/main/java/net/mtrop/doom/tools/DoomToolsMain.java
+++ b/src/main/java/net/mtrop/doom/tools/DoomToolsMain.java
@@ -529,10 +529,14 @@ public final class DoomToolsMain
 				File settingsDir = new File(Common.SETTINGS_PATH);
 				if (!settingsDir.exists())
 				{
+                                    options.stdout.println("Creating the missing DoomTools settings folder...");
+                                    if( !settingsDir.mkdirs())
+                                    {
 					options.stderr.println("ERROR: Cannot open settings folder. Not created nor found.");
 					return ERROR_DESKTOP_ERROR;
+                                    }
 				}
-				
+
 				try {
 					Desktop.getDesktop().open(settingsDir);
 				} catch (IOException e) {

--- a/src/main/java/net/mtrop/doom/tools/common/Common.java
+++ b/src/main/java/net/mtrop/doom/tools/common/Common.java
@@ -11,6 +11,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
@@ -32,7 +33,7 @@ import net.mtrop.doom.tools.struct.util.OSUtils;
 public final class Common
 {
 	/** DoomTools Config folder base. */
-    public static final String SETTINGS_PATH = OSUtils.getApplicationSettingsPath() + "/DoomTools/";
+    public static final String SETTINGS_PATH = OSUtils.getApplicationSettingsPath() + File.separator + "DoomTools" + File.separator;
 
 	/** Version number map. */
 	private static final Map<String, String> VERSION_MAP = new HashMap<>();

--- a/src/main/resources/shell/embed/app-name.sh
+++ b/src/main/resources/shell/embed/app-name.sh
@@ -17,6 +17,11 @@ MAINCLASS={{MAIN_CLASSNAME}}
 
 export DOOMTOOLS_PATH="$(cd "$(dirname $($CMD_READLINK "$0"))"; pwd)"
 export DOOMTOOLS_JAR={{JAR_NAME}}
+JAR_PATH="${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}"
+if [[ "$OSTYPE" == "cygwin"* ]]; then
+	JAR_PATH="$(cygpath -w -a "${JAR_PATH}")"
+	DOOMTOOLS_PATH="$(cygpath -w -a "${DOOMTOOLS_PATH}")"
+fi
 
 # ===========================================================================
 # Test for Java
@@ -33,11 +38,7 @@ elif [ -n "${JRE_HOME}" ]; then
 fi
 
 if [[ -n "$JAVACMD" ]]; then
-	if [[ "$OSTYPE" == "cygwin"* ]]; then
-		"$JAVACMD" -cp "$(cygpath -w -a "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}")" $JAVAOPTS $MAINCLASS $*
-	else
-		"$JAVACMD" -cp "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}" $JAVAOPTS $MAINCLASS $*
-	fi
+	"$JAVACMD" -cp "${JAR_PATH}" $JAVAOPTS $MAINCLASS $*
 else
 	echo "Java 8 or higher could not be detected. To use these tools, a JRE must be"
 	echo "installed."

--- a/src/main/resources/shell/embed/app-name.sh
+++ b/src/main/resources/shell/embed/app-name.sh
@@ -33,7 +33,11 @@ elif [ -n "${JRE_HOME}" ]; then
 fi
 
 if [[ -n "$JAVACMD" ]]; then
-	"$JAVACMD" -cp "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}" $JAVAOPTS $MAINCLASS $*
+	if [[ "$OSTYPE" == "cygwin"* ]]; then
+		"$JAVACMD" -cp "$(cygpath -w -a "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}")" $JAVAOPTS $MAINCLASS $*
+	else
+		"$JAVACMD" -cp "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}" $JAVAOPTS $MAINCLASS $*
+	fi
 else
 	echo "Java 8 or higher could not be detected. To use these tools, a JRE must be"
 	echo "installed."

--- a/src/main/resources/shell/jar/app-name.sh
+++ b/src/main/resources/shell/jar/app-name.sh
@@ -17,6 +17,11 @@ MAINCLASS={{MAIN_CLASSNAME}}
 
 export DOOMTOOLS_PATH="$(cd "$(dirname $($CMD_READLINK "$0"))"; pwd)"
 export DOOMTOOLS_JAR="jar/$((cd ${DOOMTOOLS_PATH}/jar && ls -1a *.jar) | sort | tail -1)"
+JAR_PATH="${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}"
+if [[ "$OSTYPE" == "cygwin"* ]]; then
+	JAR_PATH="$(cygpath -w -a "${JAR_PATH}")"
+	DOOMTOOLS_PATH="$(cygpath -w -a "${DOOMTOOLS_PATH}")"
+fi
 
 # ===========================================================================
 # Test for Java
@@ -33,11 +38,7 @@ elif [ -n "${JRE_HOME}" ]; then
 fi
 
 if [[ -n "$JAVACMD" ]]; then
-	if [[ "$OSTYPE" == "cygwin"* ]]; then
-		"$JAVACMD" -cp "$(cygpath -w -a "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}")" $JAVAOPTS $MAINCLASS $*
-	else
-		"$JAVACMD" -cp "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}" $JAVAOPTS $MAINCLASS $*
-	fi
+	"$JAVACMD" -cp "${JAR_PATH}" $JAVAOPTS $MAINCLASS $*
 else
 	echo "Java 8 or higher could not be detected. To use these tools, a JRE must be"
 	echo "installed."

--- a/src/main/resources/shell/jar/app-name.sh
+++ b/src/main/resources/shell/jar/app-name.sh
@@ -33,7 +33,11 @@ elif [ -n "${JRE_HOME}" ]; then
 fi
 
 if [[ -n "$JAVACMD" ]]; then
-	"$JAVACMD" -cp "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}" $JAVAOPTS $MAINCLASS $*
+	if [[ "$OSTYPE" == "cygwin"* ]]; then
+		"$JAVACMD" -cp "$(cygpath -w -a "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}")" $JAVAOPTS $MAINCLASS $*
+	else
+		"$JAVACMD" -cp "${DOOMTOOLS_PATH}/${DOOMTOOLS_JAR}" $JAVAOPTS $MAINCLASS $*
+	fi
 else
 	echo "Java 8 or higher could not be detected. To use these tools, a JRE must be"
 	echo "installed."


### PR DESCRIPTION
This addresses some path and file path issues that were preventing this working correctly with cygwin.  I'm running a windows (not cygwin) java but running doomtools under cygwin.

1.  The shell wrappers were passing paths to the jar file and `DOOMTOOLS_PATH` that were cygwin paths, not windows paths.  I addressed this by adding some calls to `cygpath` in the wrapper shell scripts when run under cygwin.  `cygpath` can translate things like `/home/dan/doomtools` to `c:\cygwin64\home\dan\doomtools`.  `cygpath` is only called when running under cygwin.
2. There was a spot in the java code that hard coded `"/"`.  I converted that to `File.separator` to get the correct thing for windows as well as linux.
3. `doomtools --settings` was failing because the setting directory did not exist on my computer.  Now if the directory does not exist, it tries to create it and only fails if the directory does not exist *and* it is unable to create it.

As a side note, I'm building under macos and then testing the result under cygwin.

Thanks for the cool tools, hope this helps.
