### PR TITLE
Fix idgames search request sort type

### DIFF
--- a/src/main/java/net/mtrop/doom/tools/doomfetch/IdGamesDriver.java
+++ b/src/main/java/net/mtrop/doom/tools/doomfetch/IdGamesDriver.java
@@ -43,7 +43,7 @@ public class IdGamesDriver extends FetchDriver
 			.parameters(
 				HTTPUtils.entry("action", "search"),
 				HTTPUtils.entry("type", "filename"),
-				HTTPUtils.entry("sort", "name"),
+				HTTPUtils.entry("sort", "filename"),
 				HTTPUtils.entry("out", "json"),
 				HTTPUtils.entry("query", name)
 		).send(JSON_READER);


### PR DESCRIPTION
The API docs don't list `name` as a valid sort type. When I try with `name`, it seems to sort the same as with the default `date`. So this PR just changes the request to use `filename` instead.