### PR TITLE
Add DoomTools Copr to package repo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ have a demo copy buildable at all times?
 #### Package Repositories
 
 - [Arch Linux AUR doomtools-bin](https://aur.archlinux.org/packages/doomtools-bin) (courtesy of @sickcodes)
-
+- [Fedora Linux Copr](https://copr.fedorainfracloud.org/coprs/electricbrass/doom/) (courtesy of @electricbrass)
 
 ### Compiling with Ant
 


### PR DESCRIPTION
I'm starting to maintain a Fedora Copr repo for a few Doom related projects, with the first thing I added being DoomTools. I see there's an AUR package listed in the readme so I thought I'd add this too.